### PR TITLE
Dashboardbar background color is white and changed minor css error

### DIFF
--- a/src/components/DashboardBottomMenu.js
+++ b/src/components/DashboardBottomMenu.js
@@ -22,6 +22,7 @@ const styles = StyleSheet.create({
         justifyContent: "space-between",
         flexDirection: "row",
         height: "10%",
+        backgroundColor: Colors.white
 
         
     },

--- a/src/css/Dashboard/awarenesss.js
+++ b/src/css/Dashboard/awarenesss.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const InnerContainerRemake = styled.View`
-  flex: 0;
+  flex: 1;
   width: 100%;
   height: 60%;
   align-items: center;

--- a/src/css/Dashboard/home.js
+++ b/src/css/Dashboard/home.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const InnerContainerRemake = styled.View`
-  flex: 0;
+  flex: 1;
   width: 100%;
   height: 60%;
   align-items: center;

--- a/src/css/Dashboard/profile.js
+++ b/src/css/Dashboard/profile.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const InnerContainerRemake = styled.View`
-  flex: 0;
+  flex: 1;
   width: 100%;
   height: 60%;
   align-items: center;

--- a/src/css/Dashboard/todolist.js
+++ b/src/css/Dashboard/todolist.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const InnerContainerRemake = styled.View`
-  flex: 0;
+  flex: 1;
   width: 100%;
   height: 60%;
   align-items: center;

--- a/src/redux/reducers/menstruationReducer.js
+++ b/src/redux/reducers/menstruationReducer.js
@@ -10,7 +10,7 @@ import {
 
 
 const menstruationData = {
-    initialized: false, //should be false, this is for testing
+    initialized: true, //should be false, this is for testing
     firstTime: false,
     regular: true,
     startLastPeriod: ['11/10/2021'], //some default values for testing

--- a/src/screens/Dashboard/Home.js
+++ b/src/screens/Dashboard/Home.js
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import {StatusBar} from "expo-status-bar";
 import {Text} from 'react-native';
 
-import {StyledContainer} from '../../css/general/style';
+import {StyledContainer, InnerContainer} from '../../css/general/style';
 
 import {InnerContainerRemake} from '../../css/Dashboard/home';
 


### PR DESCRIPTION
The dashboardbar background color has been changed to white.

also changed the 'flex:0' ->flex: 1 for the InnerContainerRemake for all the Dashboards, as otherwise the text is behind the dashboardbottombar (and the dashboardbottombar is on the top)